### PR TITLE
Added flushRX function to HardwareSerial

### DIFF
--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp
@@ -210,6 +210,11 @@ void HardwareSerial::flush()
   // the hardware finished tranmission (TXC is set).
 }
 
+void HardwareSerial::flushRX()
+{
+  _rx_buffer->head = _rx_buffer->tail;
+}
+
 size_t HardwareSerial::write(uint8_t c)
 {
   _written = true;

--- a/hardware/arduino/avr/cores/arduino/HardwareSerial.h
+++ b/hardware/arduino/avr/cores/arduino/HardwareSerial.h
@@ -126,6 +126,7 @@ class HardwareSerial : public Stream
     virtual int read(void);
     int availableForWrite(void);
     virtual void flush(void);
+    virtual void flushRX(void);
     virtual size_t write(uint8_t);
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }


### PR DESCRIPTION
Snowbots used/will be using the `flushRX()` function in at least the GPS driver since last year. This flushes the RX buffer rather than the TX buffer (which `HardwareSerial::flush()` does) (don't quote me on this explicitly, fact-check with @Dulluhan  to be absolutely certain what this is for).

Previously, we would actually go to the install directory of the arduino package to include this functionality. This pull request (and indeed, this entire fork) was mostly created to have better documentation and reliability regarding that -- we'd still need to figure out exactly how to link this fork into our IGVC-2017 project (thinking Chef) but I feel that this is a step in the right direction.
